### PR TITLE
Fixes:

### DIFF
--- a/markdown.js
+++ b/markdown.js
@@ -7,13 +7,13 @@ function loadValidTLDS() {
 	var tldsArray = [];
 
 	TLDS.forEach(function(tld){
-		tldsArray.push('\\.' + tld + '(?!\\w)');
+		tldsArray.push('\\.' + tld + '(?!\\.|\\w)');
 	});
 
 	return tldsArray.join('|');
 }
 
-var validLinkMarkDownRegEx = new RegExp(loadValidTLDS() + '|^https?:\\/\\/', "i");
+var validLinkMarkDownRegEx = new RegExp('[a-zA-Z0-9](' + loadValidTLDS() + ')|^https?:\\/\\/[a-zA-Z0-9]', "i");
 
 var _ = _ || null;
 if ((typeof require != 'undefined') && !_) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "glipdown",
 	"description": "Glip-flavored markdown",
-	"version": "0.0.21",
+	"version": "0.0.24",
 	"homepage": "https://github.com/jstrinko/glipdown",
 	"author": {
 		"name": "Jeff Strinko",

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -57,13 +57,13 @@ var tests = [
 	},
 	{
 		str: '[code]\n__awesome__ google.com\n[/code]\n__awesome__ google.com',
-		len: 209,
-		escaped_len: 209
+		len: 144,
+		escaped_len: 144
 	},
 	{
 		str: '[code]\n~~awesome~~ google.com\n[/code]\n~~awesome google.com~~',
-		len: 219,
-		escaped_len: 219 
+		len: 154,
+		escaped_len: 154 
 	},
 	{
 		str: '&gt; some stuff[code]\n&gt; some more stuff[/code]\n&gt; even moar',
@@ -72,8 +72,8 @@ var tests = [
 	},
 	{
 		str: '[code][some link](http://heynow.com)[/code][legit](http://legit.com)',
-		len: 172,
-		escaped_len: 172
+		len: 184,
+		escaped_len: 184
 	},
 	{
 		str: '[oiasjdf@Ooijasdf.com](mailto:oiasjdf@Ooijasdf.com)',
@@ -142,7 +142,7 @@ var tests = [
 	},
 	{
 		str: '[code](a=$(location).attr("href").match(/https:\/\/([^\/]+)\/r(\/[^\?]+)?(.*)/))&&4<=a.length&&history.pushState(null,null,"https://"+a[1])',
-		len: 156,
+		len: 159,
 		escaped_len: 195
 	},
 	{


### PR DESCRIPTION
the string 'HTTP://' registering as a link. must now contain at least one letter.
stings such as (www.)google.com.trailinggarbage no longer register as valid urls.
strings with double periods, such as www.github..com, no longer trigger as links

updated test cases to respect new behavior for links in [code] block.