### PR TITLE
Fix for corrupted key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "glipdown",
 	"description": "Glip-flavored markdown",
-	"version": "0.0.55",
+	"version": "0.0.56",
 	"homepage": "https://github.com/jstrinko/glipdown",
 	"author": {
 		"name": "Jeff Strinko",


### PR DESCRIPTION
Commit increments the version number to prevent the integrity checksum from failing due to having two different keys